### PR TITLE
解决使用rem布局页面时loadmore无法上拉

### DIFF
--- a/packages/loadmore/src/loadmore.vue
+++ b/packages/loadmore/src/loadmore.vue
@@ -265,7 +265,7 @@
         if (this.scrollEventTarget === window) {
           return document.body.scrollTop + document.documentElement.clientHeight >= document.body.scrollHeight;
         } else {
-          return this.$el.getBoundingClientRect().bottom <= this.scrollEventTarget.getBoundingClientRect().bottom + 1;
+          return this.$el.getBoundingClientRect().bottom <= parseInt(this.scrollEventTarget.getBoundingClientRect().bottom) + 5;
         }
       },
 


### PR DESCRIPTION
原因是 checkBottomReached方法校验出错(rem布局可能会产出小数的高度)。修改为
this.$el.getBoundingClientRect().bottom <= parseInt(this.scrollEventTarget.getBoundingClientRect().bottom) + 5; 亲测有效

